### PR TITLE
Add safe check for deprecated get_magic_quotes_runtime

### DIFF
--- a/UNL/Cache/Lite.php
+++ b/UNL/Cache/Lite.php
@@ -720,7 +720,7 @@ class UNL_Cache_Lite
         if ($fp) {
             clearstatcache();
             $length = @filesize($this->_file);
-            $mqr = get_magic_quotes_runtime();
+            $mqr = $this->_safeGetMagicQuotesRuntime();
             if ($mqr) {
                 set_magic_quotes_runtime(0);
             }
@@ -779,7 +779,7 @@ class UNL_Cache_Lite
             if ($this->_readControl) {
                 @fwrite($fp, $this->_hash($data, $this->_readControlType), 32);
             }
-            $mqr = get_magic_quotes_runtime();
+            $mqr = $this->_safeGetMagicQuotesRuntime();
             if ($mqr) {
                 set_magic_quotes_runtime(0);
             }
@@ -837,6 +837,10 @@ class UNL_Cache_Lite
         default:
             return $this->raiseError('Unknown controlType ! (available values are only \'md5\', \'crc32\', \'strlen\')', -5);
         }
+    }
+
+    protected function _safeGetMagicQuotesRuntime() {
+        return version_compare( phpversion(), '5.4', '<' ) && function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime();
     }
     
 } 


### PR DESCRIPTION
@ericras please review.  The update is needed for PHP 7.4

I will need write access to merge or will need you to merge. If you merge I will also need a new tag created after merged.

